### PR TITLE
Disable the gh-pages env when building PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,18 +2,14 @@ name: Build (PR)
 
 on:
   pull_request:
-    
+
 jobs:
   build-app:
     permissions:
       pages: write
       id-token: write
       contents: read
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
+      
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
Disable the gh-pages environment when building PRs as we're not actually trying to deploy at that time. 